### PR TITLE
Handling envs

### DIFF
--- a/data/examples/renders/shotRender.json
+++ b/data/examples/renders/shotRender.json
@@ -21,7 +21,7 @@
     ],
     "taskWrapper": "subprocess",
     "taskWrapperOptions": {
-      "user": "$UMEDIA_VERSION_PUBLISHER_USER"
+      "user": "$VERSION_PUBLISHER_USER"
     },
     "targetTemplate": "{prefix}/{job}/sequences/{seq}/{shot}/publish/{step}/{pass}/(newVersion <parentPath>)",
     "taskHolders":
@@ -51,14 +51,14 @@
         },
         "taskWrapper": "subprocess",
         "taskWrapperOptions": {
-          "user": "$UMEDIA_VERSION_PUBLISHER_USER"
+          "user": "$VERSION_PUBLISHER_USER"
         },
         "taskHolders": [
           {
             "task": "appendToVersion",
             "taskWrapper": "subprocess",
             "taskWrapperOptions": {
-              "user": "$UMEDIA_VERSION_PUBLISHER_USER"
+              "user": "$VERSION_PUBLISHER_USER"
             }
           }
         ]

--- a/data/examples/renders/turntable.json
+++ b/data/examples/renders/turntable.json
@@ -21,7 +21,7 @@
       ],
       "taskWrapper": "subprocess",
       "taskWrapperOptions": {
-        "user": "$UMEDIA_VERSION_PUBLISHER_USER"
+        "user": "$VERSION_PUBLISHER_USER"
       },
       "targetTemplate": "{prefix}/{job}/assets/{assetName}/publish/{step}/{variant}/(newVersion <parentPath>)",
       "taskHolders":
@@ -51,14 +51,14 @@
           },
           "taskWrapper": "subprocess",
           "taskWrapperOptions": {
-            "user": "$UMEDIA_VERSION_PUBLISHER_USER"
+            "user": "$VERSION_PUBLISHER_USER"
           },
           "taskHolders": [
             {
               "task": "appendToVersion",
               "taskWrapper": "subprocess",
               "taskWrapperOptions": {
-                "user": "$UMEDIA_VERSION_PUBLISHER_USER"
+                "user": "$VERSION_PUBLISHER_USER"
               }
             }
           ]

--- a/data/examples/textures/textures.json
+++ b/data/examples/textures/textures.json
@@ -24,7 +24,7 @@
       },
       "taskWrapper": "subprocess",
       "taskWrapperOptions": {
-        "user": "$UMEDIA_VERSION_PUBLISHER_USER"
+        "user": "$VERSION_PUBLISHER_USER"
       },
       "targetTemplate": "{prefix}/{job}/assets/!{assetName}/publish/texture/{variant}/(newVersion <parentPath>)",
       "taskHolders": [

--- a/data/tests/config/test.json
+++ b/data/tests/config/test.json
@@ -36,7 +36,7 @@
         },
         "taskWrapper": "subprocess",
         "taskWrapperOptions": {
-        "user": "$UMEDIA_VERSION_PUBLISHER_USER"
+        "user": "$VERSION_PUBLISHER_USER"
         }
       },
       {

--- a/src/bin/ingestor-gui.py
+++ b/src/bin/ingestor-gui.py
@@ -15,7 +15,6 @@ from PySide2 import QtCore, QtGui, QtWidgets
 class Application(QtWidgets.QApplication):
 
     __viewModes = ["group", "flat"]
-    __remoteTempDirectory = os.environ['UMEDIA_TEMP_REMOTE_DIR']
 
     def __init__(self, argv, **kwargs):
         super(Application, self).__init__(argv, **kwargs)

--- a/src/lib/ingestor/Dispatcher/Renderfarm/Renderfarm.py
+++ b/src/lib/ingestor/Dispatcher/Renderfarm/Renderfarm.py
@@ -13,18 +13,20 @@ class Renderfarm(Dispatcher):
     Optional options: label, jobTempDir, splitSize, priority, chunkifyOnTheFarm and expandOnTheFarm
     """
 
-    __defaultJobTempDir = os.environ['UMEDIA_TEMP_REMOTE_DIR']
+    __defaultJobTempDir = os.environ.get('TEMP_REMOTE_DIR', '')
     __defaultLabel = "ingestor"
     __defaultExpandOnTheFarm = False
     __defaultChunkifyOnTheFarm = False
-    __defaultPriority = int(os.environ['DISPATCHER_RENDERFARM_PRIORITY'])
-    __defaultSplitSize = int(os.environ['DISPATCHER_RENDERFARM_SPLITSIZE'])
+    __defaultPriority = int(os.environ.get('DISPATCHER_RENDERFARM_PRIORITY', 50))
+    __defaultSplitSize = int(os.environ.get('DISPATCHER_RENDERFARM_SPLITSIZE', 5))
 
     def __init__(self, *args, **kwargs):
         """
         Create a Renderfarm dispatcher object.
         """
         super(Renderfarm, self).__init__(*args, **kwargs)
+
+        assert len(self.__defaultJobTempDir), "TEMP_REMOTE_DIR env is not defined!"
 
         # setting default options
         self.setOption('label', self.__defaultLabel)

--- a/src/lib/ingestor/Task/Shotgun/aux/runImageSeqPublish.py
+++ b/src/lib/ingestor/Task/Shotgun/aux/runImageSeqPublish.py
@@ -58,7 +58,7 @@ def publish(content):
     user = sa.create_script_user(
         api_script="Toolkit",
         api_key="7839b54042ddfecdc6d0bd27e72c4499d5c04516f96dc1ff30d9bb7ac084ec7e",
-        host=os.environ["UMEDIA_SHOTGUN_URL"]
+        host=os.environ["SHOTGUN_URL"]
     )
 
     # tell the Toolkit Core API which user to use

--- a/src/lib/ingestor/Task/Shotgun/aux/runPlatePublish.py
+++ b/src/lib/ingestor/Task/Shotgun/aux/runPlatePublish.py
@@ -60,7 +60,7 @@ def publish(content):
     user = sa.create_script_user(
         api_script="Toolkit",
         api_key="7839b54042ddfecdc6d0bd27e72c4499d5c04516f96dc1ff30d9bb7ac084ec7e",
-        host=os.environ["UMEDIA_SHOTGUN_URL"]
+        host=os.environ["SHOTGUN_URL"]
     )
 
     # tell the Toolkit Core API which user to use

--- a/src/lib/ingestor/Task/Shotgun/aux/runTexturePublish.py
+++ b/src/lib/ingestor/Task/Shotgun/aux/runTexturePublish.py
@@ -16,7 +16,7 @@ def publish(content):
     user = sa.create_script_user(
         api_script="Toolkit",
         api_key="7839b54042ddfecdc6d0bd27e72c4499d5c04516f96dc1ff30d9bb7ac084ec7e",
-        host=os.environ["UMEDIA_SHOTGUN_URL"]
+        host=os.environ["SHOTGUN_URL"]
     )
 
     # tell the Toolkit Core API which user to use

--- a/tests/Task/TaskTest.py
+++ b/tests/Task/TaskTest.py
@@ -200,7 +200,7 @@ class TaskTest(BaseTestCase):
         removeTask = Task.create('remove')
         removeTask.add(crawler, crawler.var("filePath"))
         wrapper = TaskWrapper.create('subprocess')
-        wrapper.setOption('user', '$UMEDIA_VERSION_PUBLISHER_USER')
+        wrapper.setOption('user', '$VERSION_PUBLISHER_USER')
         wrapper.run(removeTask)
 
 

--- a/tests/TaskWrapper/SgPythonTest.py
+++ b/tests/TaskWrapper/SgPythonTest.py
@@ -27,7 +27,7 @@ class SgPythonTest(BaseTestCase):
         result = wrapper.run(dummyTask)
         self.assertTrue(len(result), 1)
         self.assertIn("testVar", result[0].varNames())
-        self.assertEqual(result[0].var("testVar"), os.environ.get("UMEDIA_SHOTGUN_URL"))
+        self.assertEqual(result[0].var("testVar"), os.environ.get("SHOTGUN_URL"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request is related with the upcoming changes under upipe (https://github.com/umediayvr/ubash/pull/21, https://github.com/umediayvr/usys-config/pull/1).

Also, it makes the ingestor to work in a more generic way without relying strictly on environment variables that may not be provided. Therefore, raising an exception only when the environment is requested instead of during the initialization of the ingestor.

# Change log
- Using the new convention for environment variables names define at sys-config
- Avoiding to raise an exceptions during the initialization for undefined environments